### PR TITLE
Show archived mixcloud and soundcloud show on artist pages

### DIFF
--- a/generate-artist-pages.sh
+++ b/generate-artist-pages.sh
@@ -14,6 +14,9 @@ mkdir -p "$OUTPUT_DIR"
 # Fetch artist data
 ARTISTS_JSON=$(curl -s -X GET "$ARTISTS_URL" -H "x-api-key: $API_KEY" -H "Content-Type: application/json")
 
+# Fetch all Mixcloud shows
+MIXCLOUD_SHOWS_JSON=$(curl -s "https://api.mixcloud.com/eistcork/cloudcasts/")
+
 # Validate JSON response
 if ! echo "$ARTISTS_JSON" | jq empty >/dev/null 2>&1; then
   echo "Error: API response is not valid JSON."
@@ -31,6 +34,20 @@ fi
 # Normalize filenames
 normalize_filename() {
   echo "$1" | sed 's/[ɅØøæÆ]/-/g' | iconv -f UTF-8 -t ASCII//TRANSLIT | tr -cs 'a-zA-Z0-9' '-' | sed -e 's/^-*//;s/-*$//;s/--/-/g' | tr '[:upper:]' '[:lower:]'
+}
+
+# Extract and clean artist tag values
+extract_tag_value() {
+  local tags="$1"
+  local prefix="$2"
+  echo "$tags" | jq -r --arg prefix "$prefix" '.[] | select(startswith($prefix)) | sub($prefix; "")' | tr '[:upper:]' '[:lower:]'
+}
+
+# Fetch Mixcloud shows for the artist slug
+fetch_mixcloud_hosts() {
+  local artist_username="$1"
+  # Check if the artist slug exists in any host
+  echo "$MIXCLOUD_SHOWS_JSON" | jq -r ".data[] | select(.hosts != null) | .hosts[]?.key" | grep -q "/$artist_username/"
 }
 
 # Generate social media links with <br> before the first link
@@ -69,6 +86,8 @@ generate_social_links() {
         fi
     done
 
+    # Add archive links if they exist
+
     # Join the links with " / " separator and return the result
     if [[ ${#links[@]} -gt 0 ]]; then
       echo "${links[@]}" | sed 's/ / \/ /g'
@@ -80,15 +99,61 @@ generate_social_links() {
 # Process each artist
 echo "$ARTISTS_JSON" | jq -c '.artists[]' | while read -r artist; do
   ARTIST_NAME=$(echo "$artist" | jq -r '.name')
-  ARTIST_BIO=$(echo "$artist" | jq -r '.description.content[0].content[0].text // ""')
+  ARTIST_TAGS=$(echo "$artist" | jq -c '.tags')
   ARTIST_IMAGE_URL=$(echo "$artist" | jq -r '.logo["1024x1024"] // ""')
   ARTIST_SOCIALS=$(echo "$artist" | jq -r '.socials')
-  
-  [[ -z "$ARTIST_IMAGE_URL" ]] && ARTIST_IMAGE_URL="$DEFAULT_IMAGE"
-  
   SOCIAL_LINKS=$(generate_social_links "$ARTIST_SOCIALS")
   ARTIST_FILENAME=$(normalize_filename "$ARTIST_NAME")
   FILE_PATH="$OUTPUT_DIR/$ARTIST_FILENAME.md"
+  ARTIST_BIO=$(echo "$artist" | jq -r '.description.content[0].content[0].text // ""')
+
+  # If artist image is empty, use a default image
+  [[ -z "$ARTIST_IMAGE_URL" ]] && ARTIST_IMAGE_URL="$DEFAULT_IMAGE"
+
+  # Extract artist tag values
+  MC_USERNAME=$(extract_tag_value "$ARTIST_TAGS" "MC-USERNAME_")
+  SC_USERNAME=$(extract_tag_value "$ARTIST_TAGS" "SC-USERNAME_")
+  HOST_SC_PLAYLIST=$(extract_tag_value "$ARTIST_TAGS" "HOST-SC-PLAYLIST_")
+  HOST_MC_PLAYLIST=$(extract_tag_value "$ARTIST_TAGS" "HOST-MC-PLAYLIST_")
+  EIST_MC_PLAYLIST=$(extract_tag_value "$ARTIST_TAGS" "EIST-MC-PLAYLIST_")
+
+  if [[ -n "$MC_USERNAME" || -n "$SC_USERNAME" || -n "$HOST_SC_PLAYLIST" || -n "$HOST_MC_PLAYLIST" || -n "$EIST_MC_PLAYLIST" ]]; then
+    LISTEN_BACK="#### Listen back"
+  else
+    LISTEN_BACK=""
+  fi
+
+  # Check if the artist mixcloud username exists as an eistcork Mixcloud host
+  if fetch_mixcloud_hosts "$MC_USERNAME"; then
+    LATEST_MIXCLOUD="
+<iframe width=\"100%\" height=\"60\" src=\"https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&mini=1&feed=/eistcork/hosts/$MC_USERNAME/\" frameborder=\"0\" ></iframe>"
+  else
+    LATEST_MIXCLOUD=""
+  fi
+
+  # Check if the artist SoundCloud username + playlist exists
+  if [[ -n "$SC_USERNAME" && -n "$HOST_SC_PLAYLIST" ]]; then
+    SC_PLAYLIST="
+[SoundCloud archive](https://soundcloud.com/$SC_USERNAME/sets/$HOST_SC_PLAYLIST)"
+  else
+    SC_PLAYLIST=""
+  fi
+
+  # Check if the eistcork Mixcloud playlist exists
+  if [[ -n "$EIST_MC_PLAYLIST" ]]; then
+    MC_PLAYLIST="
+[éist Mixcloud archive](https://www.mixcloud.com/eistcork/playlists/$EIST_MC_PLAYLIST)"
+  else
+    MC_PLAYLIST=""
+  fi
+
+  # Check if the artist Mixcloud username + playlist exists
+  if [[ -n "$MC_USERNAME" && -n "$HOST_MC_PLAYLIST" ]]; then
+    MC_ARTIST_PLAYLIST="
+[Mixcloud archive](https://mixcloud.com/$MC_USERNAME/playlists/$HOST_MC_PLAYLIST)"
+  else
+    MC_ARTIST_PLAYLIST=""
+  fi
 
   # Write artist markdown files
   cat > "$FILE_PATH" <<EOF
@@ -109,6 +174,16 @@ $ARTIST_BIO
 
 $SOCIAL_LINKS
 
+$LISTEN_BACK
+
+$LATEST_MIXCLOUD
+
+$MC_PLAYLIST
+
+$MC_ARTIST_PLAYLIST
+
+$SC_PLAYLIST
+
 EOF
 done
 
@@ -127,12 +202,12 @@ EOF
 # Collect artist links into a single string
 while IFS= read -r row; do
   ARTIST_NAME=$(echo "$row" | jq -r '.name')
-  ARTIST_SLUG=$(normalize_filename "$ARTIST_NAME")
+  MC_USERNAME=$(normalize_filename "$ARTIST_NAME")
 
   if [[ -n "$ARTIST_LINKS" ]]; then
     ARTIST_LINKS+=" / "
   fi
-  ARTIST_LINKS+="[$ARTIST_NAME](/artists/$ARTIST_SLUG)"
+  ARTIST_LINKS+="[$ARTIST_NAME](/artists/$MC_USERNAME)"
 done < <(echo "$ARTISTS_JSON" | jq -c '.artists[]')
 
 echo "$ARTIST_LINKS" >> "$OUTPUT_FILE"


### PR DESCRIPTION
Mixcloud API is limited, but it does allow you to show the last archived show for shows tagged with a certain host, [for example](https://player-widget.mixcloud.com/widget/iframe/?feed=/eistcork/hosts/oootini/).

oootini is the Mixcloud user for Aidan Reilly. "oootini" is added as a tag in RadioCult. When that is in place, and a show has been tagged with that username, render the last eistcork Mixcloud show where that host user is tagged.  

TL/DR

**Upload a mixcloud show from RadioCult tagged to your Mixcloud username, and add that username in Radiocult in as a tag.** 

There are a number of possible configurations. 

1. Upload your show to the eistcork account with your Mixcloud username as host. Add a tag in your artist profile in Radiocult with your username prefaced by `mc-username_`, for example, `mc-username_oootini`.
2.  Upload your show to the eistcork account with your Mixcloud username set as host, and create a playlist under your own user account. add a tag in radiocult with your username prefaced by `mc-username_` and your playlist prefaced by `host-mc-playlist_`, for example, `host-mc-playlist_infinite-details`.
3. For soundcloud, repost the uploaded show, create a playlists for the shows under your own account, and use for example, `host-sc-playlist_infinite-details` and `sc-username_oootini`.

When the website gets built again, usually every few hours, you will get output like this on the artist page:
![image](https://github.com/user-attachments/assets/b0b10ee5-61fd-4b7d-81d8-e35f525bf8b3)